### PR TITLE
Unicode literals warning when using python2.7

### DIFF
--- a/ivona_speak/command_line.py
+++ b/ivona_speak/command_line.py
@@ -9,6 +9,9 @@ from ivona_api import IvonaAPI
 from ivona_api.exceptions import IvonaAPIException
 
 
+click.disable_unicode_literals_warning = True
+
+
 @click.group(cls=DefaultGroup, default='synthesize', default_if_no_args=True)
 def cli():
     """


### PR DESCRIPTION
When using python 2.7 you would get the following warnings after `ivona-speak --help`:
```
ivona-speak/ivona_speak/command_line.py:12: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.group(cls=DefaultGroup, default='synthesize', default_if_no_args=True)
ivona-speak/ivona_speak/command_line.py:36: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.argument('text', type=str)
ivona-speak/ivona_speak/command_line.py:65: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  help="Filter voice by gender.")
```